### PR TITLE
Fix include path to compile on case-sensitive file systems and some

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # NOTE: I don't use CMake so this has not been tested
 set(COMPONENT_SRCDIRS "freertos-addons-master/c/Source freertos-addons-master/c++/Source")
-set(COMPONENT_ADD_INCLUDEDIRS "freertos-addons-master/c/Source/Include freertos-addons-master/c++/Source/Include freertos-addons-master")
+set(COMPONENT_ADD_INCLUDEDIRS "freertos-addons-master/c/Source/include freertos-addons-master/c++/Source/include freertos-addons-master")
 
 register_component()

--- a/component.mk
+++ b/component.mk
@@ -2,8 +2,8 @@
 SRCDIRS := freertos-addons-master/c/Source 
 SRCDIRS += freertos-addons-master/c++/Source 
 
-INCLDIRS := freertos-addons-master/c/Source/Include 
-INCLDIRS += freertos-addons-master/c++/Source/Include
+INCLDIRS := freertos-addons-master/c/Source/include 
+INCLDIRS += freertos-addons-master/c++/Source/include
 INCLDIRS += freertos-addons-master
 
 COMPONENT_ADD_INCLUDEDIRS := $(INCLDIRS)

--- a/freertos-addons-master/c++/Source/cthread.cpp
+++ b/freertos-addons-master/c++/Source/cthread.cpp
@@ -43,8 +43,8 @@
 
 using namespace cpp_freertos;
 
-
-volatile bool Thread::SchedulerActive = false;
+// In ESP-IDF, the scheduler is already started before app_main()
+volatile bool Thread::SchedulerActive = true; 
 MutexStandard Thread::StartGuardLock;
 
 
@@ -56,12 +56,12 @@ MutexStandard Thread::StartGuardLock;
 Thread::Thread( const std::string pcName,
                 uint16_t usStackDepth,
                 UBaseType_t uxPriority,
-                const uint8_t coreID)
+                core_id_t coreID)
     :   Name(pcName), 
         StackDepth(usStackDepth), 
         Priority(uxPriority),
         ThreadStarted(false),
-        CoreID(coreID)
+        coreID(coreID)
 {
 #if (INCLUDE_vTaskDelayUntil == 1)
     delayUntilInitialized = false;
@@ -71,12 +71,12 @@ Thread::Thread( const std::string pcName,
 
 Thread::Thread( uint16_t usStackDepth,
                 UBaseType_t uxPriority,
-                const uint8_t coreID)
+                core_id_t coreID)
     :   Name("Default"), 
         StackDepth(usStackDepth), 
         Priority(uxPriority),
         ThreadStarted(false),
-        CoreID(coreID)
+        coreID(coreID)
 {
 #if (INCLUDE_vTaskDelayUntil == 1)
     delayUntilInitialized = false;
@@ -91,11 +91,11 @@ Thread::Thread( uint16_t usStackDepth,
 Thread::Thread( const char *pcName,
                 uint16_t usStackDepth,
                 UBaseType_t uxPriority,
-                const uint8_t coreID)
+                core_id_t coreID)
     :   StackDepth(usStackDepth),
         Priority(uxPriority),
         ThreadStarted(false),
-        CoreID(coreID)
+        coreID(coreID)
 {
     for (int i = 0; i < configMAX_TASK_NAME_LEN - 1; i++) {
         Name[i] = *pcName;
@@ -113,11 +113,11 @@ Thread::Thread( const char *pcName,
 
 Thread::Thread( uint16_t usStackDepth,
                 UBaseType_t uxPriority,
-                const uint8_t coreID)
+                core_id_t coreID)
     :   StackDepth(usStackDepth),
         Priority(uxPriority),
         ThreadStarted(false),
-        CoreID(coreID)
+        coreID(coreID)
 {
     memset(Name, 0, sizeof(Name));
 #if (INCLUDE_vTaskDelayUntil == 1)
@@ -165,7 +165,7 @@ bool Thread::Start()
                                 this,
                                 Priority,
                                 &handle,
-                                CoreID);
+                                coreID);
 #else 
 
     BaseType_t rc = xTaskCreatePinnedToCore(TaskFunctionAdapter,
@@ -174,7 +174,7 @@ bool Thread::Start()
                                 this,
                                 Priority,
                                 &handle,
-                                CoreID);
+                                coreID);
 #endif
 
     return rc != pdPASS ? false : true;

--- a/freertos-addons-master/c++/Source/cworkqueue.cpp
+++ b/freertos-addons-master/c++/Source/cworkqueue.cpp
@@ -64,7 +64,7 @@ WorkQueue::WorkQueue(   const char * const Name,
                         uint16_t StackDepth,
                         UBaseType_t Priority,
                         UBaseType_t maxWorkItems,
-                        const uint8_t CoreID)
+                        core_id_t coreID)
 {
     //
     //  Build the Queue first, since the Thread is going to access 
@@ -72,7 +72,7 @@ WorkQueue::WorkQueue(   const char * const Name,
     //
     WorkItemQueue = new Queue(maxWorkItems, sizeof(WorkItem *));
     ThreadComplete = new BinarySemaphore();
-    WorkerThread = new CWorkerThread(Name, StackDepth, Priority, CoreID, this);
+    WorkerThread = new CWorkerThread(Name, StackDepth, Priority, coreID, this);
     //
     //  Our ctor chain is complete, we can start.
     //
@@ -83,7 +83,7 @@ WorkQueue::WorkQueue(   const char * const Name,
 WorkQueue::WorkQueue(   uint16_t StackDepth,
                         UBaseType_t Priority,
                         UBaseType_t maxWorkItems,
-                        const uint8_t CoreID)
+                        core_id_t coreID)
 {
     //
     //  Build the Queue first, since the Thread is going to access 
@@ -91,7 +91,7 @@ WorkQueue::WorkQueue(   uint16_t StackDepth,
     //
     WorkItemQueue = new Queue(maxWorkItems, sizeof(WorkItem *));
     ThreadComplete = new BinarySemaphore();
-    WorkerThread = new CWorkerThread(StackDepth, Priority, CoreID, this);
+    WorkerThread = new CWorkerThread(StackDepth, Priority, coreID, this);
     //
     //  Our ctor chain is complete, we can start.
     //
@@ -145,18 +145,18 @@ bool WorkQueue::QueueWork(WorkItem *work)
 WorkQueue::CWorkerThread::CWorkerThread(const char * const Name,
                                         uint16_t StackDepth,
                                         UBaseType_t Priority,
-                                        const uint8_t CoreID,
+                                        core_id_t coreID,
                                         WorkQueue *Parent)
-    : Thread(Name, StackDepth, Priority, CoreID), ParentWorkQueue(Parent)
+    : Thread(Name, StackDepth, Priority, coreID), ParentWorkQueue(Parent)
 {
 }
 
 
 WorkQueue::CWorkerThread::CWorkerThread(uint16_t StackDepth,
                                         UBaseType_t Priority,
-                                        const uint8_t CoreID,
+                                        core_id_t coreID,
                                         WorkQueue *Parent)
-    : Thread(StackDepth, Priority, CoreID), ParentWorkQueue(Parent)
+    : Thread(StackDepth, Priority, coreID), ParentWorkQueue(Parent)
 {
 }
 

--- a/freertos-addons-master/c++/Source/include/thread.hpp
+++ b/freertos-addons-master/c++/Source/include/thread.hpp
@@ -68,6 +68,11 @@
 
 namespace cpp_freertos {
 
+// Using espressif's naming convention
+enum core_id_t {
+   PRO_CPU = 0,
+   APP_CPU = 1     
+};
 
 /**
  *  Wrapper class around FreeRTOS's implementation of a task.
@@ -97,18 +102,18 @@ class Thread {
          *  @param Name Name of the thread. Only useful for debugging.
          *  @param StackDepth Number of "words" allocated for the Thread stack.
          *  @param Priority FreeRTOS priority of this Thread.
-         *  @param ESP-IDF Core ID (0 for Pro, 1 for App)
+         *  @param ESP-IDF Core ID (PRO_CPU or APP_CPU)
          */
 #ifndef CPP_FREERTOS_NO_CPP_STRINGS
         Thread( const std::string Name,
                 uint16_t StackDepth,
                 UBaseType_t Priority,
-                const uint8_t CoreID);
+                core_id_t coreID);
 #else
         Thread( const char *Name,
                 uint16_t StackDepth,
                 UBaseType_t Priority,
-                const uint8_t CoreID);
+                core_id_t coreID);
 #endif
 
         /**
@@ -116,11 +121,11 @@ class Thread {
          *
          *  @param StackDepth Number of "words" allocated for the Thread stack.
          *  @param Priority FreeRTOS priority of this Thread.
-         *  @param ESP-IDF Core ID (0 for Pro, 1 for App)
+         *  @param ESP-IDF Core ID (PRO_CPU or APP_CPU)
          */
         Thread( uint16_t StackDepth,
                 UBaseType_t Priority,
-                const uint8_t CoreID);
+                core_id_t coreID);
 
         /**
          *  Starts a thread.
@@ -173,8 +178,9 @@ class Thread {
          */
         static inline void StartScheduler()
         {
-            SchedulerActive = true;
-            // vTaskStartScheduler();
+        // In ESP-IDF, the scheduler is already started before app_main()
+        //     SchedulerActive = true;
+        //     vTaskStartScheduler();
         }
 
         /**
@@ -188,8 +194,9 @@ class Thread {
          */
         static inline void EndScheduler()
         {
-            vTaskEndScheduler();
-            SchedulerActive = false;
+        // vTaskEndScheduler has only been implemented for the x86 Real Mode PC port.
+        //     vTaskEndScheduler();
+        //     SchedulerActive = false;
         }
 
 #if (INCLUDE_vTaskSuspend == 1)
@@ -450,7 +457,7 @@ class Thread {
         /**
          *  Esp-Idf core ID
          */
-        const uint8_t CoreID;
+        core_id_t coreID;
 
         /**
          *  Make sure no one calls Start more than once.

--- a/freertos-addons-master/c++/Source/include/workqueue.hpp
+++ b/freertos-addons-master/c++/Source/include/workqueue.hpp
@@ -153,7 +153,7 @@ class WorkQueue {
                     uint16_t StackDepth = DEFAULT_WORK_QUEUE_STACK_SIZE,
                     UBaseType_t Priority = DEFAULT_WORK_QUEUE_PRIORITY,
                     UBaseType_t MaxWorkItems = DEFAULT_MAX_WORK_ITEMS,
-                    const uint8_t CoreID = 1);
+                    core_id_t coreID = APP_CPU);
 
         /**
          *  Constructor to create an unnamed WorkQueue.
@@ -167,7 +167,7 @@ class WorkQueue {
         WorkQueue(  uint16_t StackDepth = DEFAULT_WORK_QUEUE_STACK_SIZE,
                     UBaseType_t Priority = DEFAULT_WORK_QUEUE_PRIORITY,
                     UBaseType_t MaxWorkItems = DEFAULT_MAX_WORK_ITEMS,
-                    const uint8_t CoreID = 1);
+                    core_id_t coreID = APP_CPU);
 
 #if (INCLUDE_vTaskDelete == 1)
         /**
@@ -218,12 +218,12 @@ class WorkQueue {
                 CWorkerThread(  const char * const Name,
                                 uint16_t StackDepth,
                                 UBaseType_t Priority,
-                                const uint8_t CoreID,
+                                core_id_t coreID,
                                 WorkQueue *Parent);
 
                 CWorkerThread(  uint16_t StackDepth,
                                 UBaseType_t Priority,
-                                const uint8_t CoreID,
+                                core_id_t coreID,
                                 WorkQueue *Parent);
 
                 virtual ~CWorkerThread();


### PR DESCRIPTION
Thanks for making this port!

This PR includes a fix to compile on Linux or other case-sensitive file systems, adds a coreID enum, standardizes coreID naming, removes call to vTaskEndScheduler (because it is not implemented for the ESP32).