### PR TITLE
compatibility with  PlatformIO IDE

### DIFF
--- a/freertos-addons-master/c++/Source/include/thread.hpp
+++ b/freertos-addons-master/c++/Source/include/thread.hpp
@@ -71,7 +71,8 @@ namespace cpp_freertos {
 // Using espressif's naming convention
 enum core_id_t {
    PRO_CPU = 0,
-   APP_CPU = 1     
+   APP_CPU = 1,
+   NO_AFFINITY = tskNO_AFFINITY     
 };
 
 /**

--- a/library.json
+++ b/library.json
@@ -1,0 +1,8 @@
+{
+    "build":
+    {
+        "flags":"-I ./freertos-addons-master",
+        "includeDir": "./freertos-addons-master/c++/Source/include",
+        "srcDir": "./freertos-addons-master/c++/Source"     
+    }    
+}


### PR DESCRIPTION
A library.json file was added to make the library compatible with the Platformio build process. Now the library just need to be cloned inside the 'lib' folder.

A new field was added into coreID enum to allow the scheduler creates a task on any CPU it decides.